### PR TITLE
Fix node install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ secrets.
 
 ## Installation
 
-If you have node.js installed, simply `npm -g vault-pki-client`
+If you have node.js installed, simply `npm install -g vault-pki-client`
 
 If you don't have node.js installed, you can [download a binary package](https://github.com/issacg/vault-pki-client/releases/latest)
 


### PR DESCRIPTION
The install command in the readme was wrong, this fixes it 👍 
