### PR TITLE
Follow redirects in HTTP requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,8 @@ var renewVaultToken = (function() {
 function buildReqOpts() {
     var reqOpts = {
         ca:[],
-        rejectUnauthorized: !config.vault.server["tls-skip-verify"]
+        rejectUnauthorized: !config.vault.server["tls-skip-verify"],
+        followAllRedirects: false
     };
 
     if (config.vault.server["ca-path"]) {


### PR DESCRIPTION
By following redirects, the client doesn't have to point to the master when running in multi-server mode.
